### PR TITLE
fix: stop retrying DBaaS requests when context is cancelled

### DIFF
--- a/dbaas_client.go
+++ b/dbaas_client.go
@@ -216,6 +216,9 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 	delay := configloader.GetOrDefault("dbaas.baseclient.retry.delay-ms", 5000).(int)
 	var resp *http.Response
 	for i := 0; i <= maxNumberOfAttempts; i++ {
+		if ctx.Err() != nil {
+			return nil, model.DbaaSCreateDbError{HttpCode: 0, Message: "Request canceled.", Errors: ctx.Err()}
+		}
 		var err error
 		resp, err = d.client.DoRequest(ctx, httpMethod, dbaasUrl, map[string][]string{
 			"Content-Type": {"application/json"},
@@ -233,7 +236,9 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 					Errors:   fmt.Errorf("dbaas error: %w", err),
 				}
 			} else {
-				time.Sleep(time.Duration(delay) * time.Millisecond)
+				if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
+					return nil, err
+				}
 				continue
 			}
 		}
@@ -245,10 +250,14 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 			hasBeenInterrupted = true
 		} else if resp.StatusCode == http.StatusAccepted {
 			logger.InfoC(ctx, "Secure %s request to %s got status code %d, database is not created yet, retrying %d out of %d", httpMethod, dbaasUrl, resp.StatusCode, i, maxNumberOfAttempts)
-			time.Sleep(time.Duration(delay) * time.Millisecond)
+			if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
+				return nil, err
+			}
 		} else if resp.StatusCode >= 300 {
 			logger.WarnC(ctx, "Request to %s %s failed with status code %d, retrying %d out of %d", httpMethod, dbaasUrl, resp.StatusCode, i, maxNumberOfAttempts)
-			time.Sleep(time.Duration(delay) * time.Millisecond)
+			if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
+				return nil, err
+			}
 		}
 
 		if i == maxNumberOfAttempts || hasBeenInterrupted {
@@ -309,6 +318,15 @@ func isValidClassifier(ctx context.Context, classifier map[string]interface{}) e
 		return err
 	}
 	return nil
+}
+
+func sleepOrCancel(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return model.DbaaSCreateDbError{HttpCode: 0, Message: "Request canceled.", Errors: ctx.Err()}
+	}
 }
 
 func (d *dbaasClientImpl) checkDbaasApiVersion(ctx context.Context) error {

--- a/dbaas_client.go
+++ b/dbaas_client.go
@@ -254,24 +254,35 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 		}
 
 		if i == maxNumberOfAttempts || hasBeenInterrupted {
-			responseBody, _ := io.ReadAll(resp.Body)
+			responseBody, readErr := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			apiErr := d.checkDbaasApiVersion(ctx)
-			if apiErr != nil {
+			var bodyErr error
+			if readErr != nil {
+				bodyErr = fmt.Errorf("request to DbaaS failed, error reading response body: %w", readErr)
+			} else {
+				bodyErr = fmt.Errorf("request to DbaaS failed with response body: %s", responseBody)
+			}
+
+			if apiErr := d.checkDbaasApiVersion(ctx); apiErr != nil {
 				return nil, model.DbaaSCreateDbError{
 					HttpCode: resp.StatusCode,
 					Message:  "API v3 dbaas-aggregator is not available",
 					Errors:   apiErr,
 				}
 			}
-			errMsg := "Failed to get response from DbaaS."
+
 			if hasBeenInterrupted {
-				errMsg = "Incorrect response from DbaaS. Stop retrying"
+				return nil, model.DbaaSCreateDbError{
+					HttpCode: resp.StatusCode,
+					Message:  "Incorrect response from DbaaS. Stop retrying",
+					Errors:   bodyErr,
+				}
 			}
+
 			return nil, model.DbaaSCreateDbError{
 				HttpCode: resp.StatusCode,
-				Message:  errMsg,
-				Errors:   errors.New(fmt.Sprintf("request to DbaaS failed with response body: %s", responseBody)),
+				Message:  "Failed to get response from DbaaS.",
+				Errors:   bodyErr,
 			}
 		}
 

--- a/dbaas_client.go
+++ b/dbaas_client.go
@@ -235,12 +235,11 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 					Message:  errMsg,
 					Errors:   fmt.Errorf("dbaas error: %w", err),
 				}
-			} else {
-				if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
-					return nil, err
-				}
-				continue
 			}
+			if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
+				return nil, err
+			}
+			continue
 		}
 
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
@@ -250,28 +249,21 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 			hasBeenInterrupted = true
 		} else if resp.StatusCode == http.StatusAccepted {
 			logger.InfoC(ctx, "Secure %s request to %s got status code %d, database is not created yet, retrying %d out of %d", httpMethod, dbaasUrl, resp.StatusCode, i, maxNumberOfAttempts)
-			if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
-				return nil, err
-			}
 		} else if resp.StatusCode >= 300 {
 			logger.WarnC(ctx, "Request to %s %s failed with status code %d, retrying %d out of %d", httpMethod, dbaasUrl, resp.StatusCode, i, maxNumberOfAttempts)
-			if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
-				return nil, err
-			}
 		}
 
 		if i == maxNumberOfAttempts || hasBeenInterrupted {
-			err = d.checkDbaasApiVersion(ctx)
-			if err != nil {
+			responseBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			apiErr := d.checkDbaasApiVersion(ctx)
+			if apiErr != nil {
 				return nil, model.DbaaSCreateDbError{
 					HttpCode: resp.StatusCode,
 					Message:  "API v3 dbaas-aggregator is not available",
-					Errors:   err,
+					Errors:   apiErr,
 				}
 			}
-			responseBody, _ := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
-
 			errMsg := "Failed to get response from DbaaS."
 			if hasBeenInterrupted {
 				errMsg = "Incorrect response from DbaaS. Stop retrying"
@@ -281,6 +273,11 @@ func (d *dbaasClientImpl) retryRequestToDbaaS(ctx context.Context, dbaasUrl stri
 				Message:  errMsg,
 				Errors:   errors.New(fmt.Sprintf("request to DbaaS failed with response body: %s", responseBody)),
 			}
+		}
+
+		_ = resp.Body.Close()
+		if err := sleepOrCancel(ctx, time.Duration(delay)*time.Millisecond); err != nil {
+			return nil, err
 		}
 	}
 	return resp, nil

--- a/dbaas_client_test.go
+++ b/dbaas_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3/model"
 	"github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3/model/rest"
@@ -514,6 +515,62 @@ func (suite *DbaasClientTestSuite) TestIsValidClassifier_ErrorClassifierWithoutT
 	err := isValidClassifier(context.Background(), classifier)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "classifier is not valid.")
+}
+
+func (suite *DbaasClientTestSuite) TestSendRequestToDbaas_ImmediateReturnOnCanceledContext() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	requestCount := 0
+	AddHandler(Contains(dbaasGetOrCreateEndpointV3), func(writer http.ResponseWriter, request *http.Request) {
+		requestCount++
+		writer.WriteHeader(http.StatusOK)
+	})
+
+	dbClient := NewDbaasClient()
+	start := time.Now()
+	_, err := dbClient.GetOrCreateDb(ctx, dbType, suite.classifier, rest.BaseDbParams{})
+	elapsed := time.Since(start)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), 0, requestCount)
+	assert.Less(suite.T(), elapsed, 100*time.Millisecond)
+}
+
+func (suite *DbaasClientTestSuite) TestSendRequestToDbaas_StopsRetryingOnContextCancel() {
+	configloader.InitWithSourcesArray(configloader.BasePropertySources(suite.params))
+	ctx, cancel := context.WithCancel(context.Background())
+	requestCount := 0
+	AddHandler(Contains(dbaasGetOrCreateEndpointV3), func(writer http.ResponseWriter, request *http.Request) {
+		requestCount++
+		cancel()
+		writer.WriteHeader(http.StatusInternalServerError)
+	})
+
+	dbClient := NewDbaasClient()
+	start := time.Now()
+	_, err := dbClient.GetOrCreateDb(ctx, dbType, suite.classifier, rest.BaseDbParams{})
+	elapsed := time.Since(start)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), 1, requestCount)
+	assert.Less(suite.T(), elapsed, 100*time.Millisecond)
+}
+
+func (suite *DbaasClientTestSuite) TestSendRequestToDbaas_StopsRetryingOnContextDeadline() {
+	configloader.InitWithSourcesArray(configloader.BasePropertySources(suite.params))
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	requestCount := 0
+	AddHandler(Contains(dbaasGetOrCreateEndpointV3), func(writer http.ResponseWriter, request *http.Request) {
+		requestCount++
+		writer.WriteHeader(http.StatusInternalServerError)
+	})
+
+	dbClient := NewDbaasClient()
+	start := time.Now()
+	_, err := dbClient.GetOrCreateDb(ctx, dbType, suite.classifier, rest.BaseDbParams{})
+	elapsed := time.Since(start)
+	assert.Error(suite.T(), err)
+	assert.LessOrEqual(suite.T(), requestCount, 2)
+	assert.Less(suite.T(), elapsed, 500*time.Millisecond)
 }
 
 func TestSuite(t *testing.T) {


### PR DESCRIPTION
### Problem
  
When something triggers DB reconnection (cache entry evicted, GetOrCreateDb called), the retry loop in retryRequestToDbaaS continued firing even after the context was cancelled. Each attempt returned instantly with context canceled, but time.Sleep blocked unconditionally between retries — up to 12 × 5 s = 60 s holding the DbaaSCache write mutex the entire time. All concurrent requests queued behind that mutex had their contexts expire too, creating an unrecoverable loop that required a pod restart.

### Changes

- Added a ctx.Err() guard at the top of each retry iteration — exits before attempting a network call if the context is already done.
- Replaced all time.Sleep calls with a sleepOrCancel helper that uses select on time.After vs ctx.Done(), so inter-retry delays are interrupted immediately on cancellation.

### Tests

- TestSendRequestToDbaas_ImmediateReturnOnCanceledContext — pre-cancelled context, 0 server hits
- TestSendRequestToDbaas_StopsRetryingOnContextCancel — cancel fired from server handler after first request
- TestSendRequestToDbaas_StopsRetryingOnContextDeadline — short context deadline bounds the exit time

Simpler version of #82.